### PR TITLE
Everything is a stream

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -11,20 +11,26 @@
     <PaketRootPath>$(MSBuildThisFileDirectory)..\</PaketRootPath>
     <PaketRestoreCacheFile>$(PaketRootPath)paket-files\paket.restore.cached</PaketRestoreCacheFile>
     <PaketLockFilePath>$(PaketRootPath)paket.lock</PaketLockFilePath>
+    <PaketBootstrapperStyle>classic</PaketBootstrapperStyle>
+    <PaketBootstrapperStyle Condition="Exists('$(PaketToolsPath)paket.bootstrapper.proj')">proj</PaketBootstrapperStyle>
+    <PaketExeImage>assembly</PaketExeImage>
+    <PaketExeImage Condition=" '$(PaketBootstrapperStyle)' == 'proj' ">native</PaketExeImage>
     <MonoPath Condition="'$(MonoPath)' == '' And Exists('/Library/Frameworks/Mono.framework/Commands/mono')">/Library/Frameworks/Mono.framework/Commands/mono</MonoPath>
     <MonoPath Condition="'$(MonoPath)' == ''">mono</MonoPath>
     <!-- Paket command -->
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND Exists('$(PaketToolsPath)paket')">$(PaketToolsPath)paket</PaketExePath>
     <PaketExePath Condition=" '$(PaketExePath)' == '' AND Exists('$(PaketRootPath)paket.exe')">$(PaketRootPath)paket.exe</PaketExePath>
-    <PaketExePath Condition=" '$(PaketExePath)' == '' ">$(PaketToolsPath)paket.exe</PaketExePath>
-    <PaketCommand Condition=" '$(OS)' == 'Windows_NT'">"$(PaketExePath)"</PaketCommand>
-    <PaketCommand Condition=" '$(OS)' != 'Windows_NT' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketExePath)"</PaketCommand>
 
-    <!-- .net core fdd -->
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' ">$(PaketToolsPath)paket.exe</PaketExePath>
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND '$(PaketExeImage)' == 'assembly' ">$(PaketToolsPath)paket.exe</PaketExePath>
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND '$(PaketExeImage)' == 'native' ">$(PaketToolsPath)paket</PaketExePath>
+
+    <!-- Paket command -->
     <_PaketExeExtension>$([System.IO.Path]::GetExtension("$(PaketExePath)"))</_PaketExeExtension>
-    <PaketCommand Condition=" '$(_PaketExeExtension)' == '.dll' ">dotnet "$(PaketExePath)"</PaketCommand>
-
-    <!-- no extension is a shell script -->
-    <PaketCommand Condition=" '$(_PaketExeExtension)' == '' ">"$(PaketExePath)"</PaketCommand>
+    <PaketCommand Condition=" '$(PaketCommand)' == '' AND '$(_PaketExeExtension)' == '.dll' ">dotnet "$(PaketExePath)"</PaketCommand>
+    <PaketCommand Condition=" '$(PaketCommand)' == '' AND '$(OS)' == 'Windows_NT'">"$(PaketExePath)"</PaketCommand>
+    <PaketCommand Condition=" '$(PaketCommand)' == '' AND '$(OS)' != 'Windows_NT' AND '$(_PaketExeExtension)' == '.exe' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketExePath)"</PaketCommand>
+    <PaketCommand Condition=" '$(PaketCommand)' == '' AND '$(OS)' != 'Windows_NT'">"$(PaketExePath)"</PaketCommand>
 
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' AND Exists('$(PaketRootPath)paket.bootstrapper.exe')">$(PaketRootPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' ">$(PaketToolsPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
@@ -38,7 +44,11 @@
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
   </PropertyGroup>
 
-  <Target Name="PaketRestore" Condition="'$(PaketRestoreDisabled)' != 'True'" BeforeTargets="_GenerateDotnetCliToolReferenceSpecs;_GenerateProjectRestoreGraphPerFramework;_GenerateRestoreGraphWalkPerFramework;CollectPackageReferences" >
+  <Target Name="PaketBootstrapping" Condition="Exists('$(PaketToolsPath)paket.bootstrapper.proj')">
+    <MSBuild Projects="$(PaketToolsPath)paket.bootstrapper.proj" Targets="Restore" />
+  </Target>
+
+  <Target Name="PaketRestore" Condition="'$(PaketRestoreDisabled)' != 'True'" BeforeTargets="_GenerateDotnetCliToolReferenceSpecs;_GenerateProjectRestoreGraphPerFramework;_GenerateRestoreGraphWalkPerFramework;CollectPackageReferences" DependsOnTargets="PaketBootstrapping">
 
     <!-- Step 1 Check if lockfile is properly restored -->
     <PropertyGroup>
@@ -77,7 +87,7 @@
     </PropertyGroup>
 
     <!-- Do a global restore if required -->
-    <Exec Command='$(PaketBootStrapperCommand)' Condition="Exists('$(PaketBootStrapperExePath)') AND !(Exists('$(PaketExePath)'))" ContinueOnError="false" />
+    <Exec Command='$(PaketBootStrapperCommand)' Condition=" '$(PaketBootstrapperStyle)' == 'classic' AND Exists('$(PaketBootStrapperExePath)') AND !(Exists('$(PaketExePath)'))" ContinueOnError="false" />
     <Exec Command='$(PaketCommand) restore' Condition=" '$(PaketRestoreRequired)' == 'true' " ContinueOnError="false" />
 
     <!-- Step 2 Detect project specific changes -->
@@ -141,14 +151,17 @@
 
     <ItemGroup Condition="($(DesignTimeBuild) != true OR '$(PaketPropsLoaded)' != 'true') AND '@(PaketReferencesFileLines)' != '' " >
       <PaketReferencesFileLinesInfo Include="@(PaketReferencesFileLines)" >
+        <Splits>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',').Length)</Splits>
         <PackageName>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[0])</PackageName>
         <PackageVersion>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[1])</PackageVersion>
         <AllPrivateAssets>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[4])</AllPrivateAssets>
+        <CopyLocal Condition="'$(Splits)' == '6'">$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[5])</CopyLocal>
       </PaketReferencesFileLinesInfo>
       <PackageReference Include="%(PaketReferencesFileLinesInfo.PackageName)">
         <Version>%(PaketReferencesFileLinesInfo.PackageVersion)</Version>
         <PrivateAssets Condition=" ('%(PaketReferencesFileLinesInfo.AllPrivateAssets)' == 'true') Or ('$(PackAsTool)' == 'true') ">All</PrivateAssets>
-        <ExcludeAssets Condition="%(PaketReferencesFileLinesInfo.AllPrivateAssets) == 'exclude'">runtime</ExcludeAssets>
+        <ExcludeAssets Condition=" '%(PaketReferencesFileLinesInfo.Splits)' == '6' And %(PaketReferencesFileLinesInfo.CopyLocal) == 'false'">runtime</ExcludeAssets>
+        <ExcludeAssets Condition=" '%(PaketReferencesFileLinesInfo.Splits)' != '6' And %(PaketReferencesFileLinesInfo.AllPrivateAssets) == 'exclude'">runtime</ExcludeAssets>
         <Publish Condition=" '$(PackAsTool)' == 'true' ">true</Publish>
       </PackageReference>
     </ItemGroup>
@@ -181,19 +194,27 @@
   <Target Name="PaketDisableDirectPack" AfterTargets="_IntermediatePack" BeforeTargets="GenerateNuspec" Condition="('$(IsPackable)' == '' Or '$(IsPackable)' == 'true') And Exists('$(MSBuildProjectDirectory)/obj/$(MSBuildProjectFile).references')" >
     <PropertyGroup>
       <ContinuePackingAfterGeneratingNuspec>false</ContinuePackingAfterGeneratingNuspec>
+      <DetectedMSBuildVersion>$(MSBuildVersion)</DetectedMSBuildVersion>
+      <DetectedMSBuildVersion Condition="$(MSBuildVersion) == ''">15.8.0</DetectedMSBuildVersion>
     </PropertyGroup>
   </Target>
 
   <Target Name="PaketOverrideNuspec" AfterTargets="GenerateNuspec" Condition="('$(IsPackable)' == '' Or '$(IsPackable)' == 'true') And Exists('$(MSBuildProjectDirectory)/obj/$(MSBuildProjectFile).references')" >
     <ItemGroup>
       <_NuspecFilesNewLocation Include="$(BaseIntermediateOutputPath)$(Configuration)\*.nuspec"/>
+      <MSBuildMajorVersion Include="$(DetectedMSBuildVersion.Replace(`-`, `.`).Split(`.`)[0])" />
+      <MSBuildMinorVersion Include="$(DetectedMSBuildVersion.Replace(`-`, `.`).Split(`.`)[1])" />
     </ItemGroup>
 
     <PropertyGroup>
       <PaketProjectFile>$(MSBuildProjectDirectory)/$(MSBuildProjectFile)</PaketProjectFile>
       <ContinuePackingAfterGeneratingNuspec>true</ContinuePackingAfterGeneratingNuspec>
-      <UseNewPack>false</UseNewPack>
-      <UseNewPack Condition=" '$(NuGetToolVersion)' != '4.0.0' ">true</UseNewPack>
+      <UseMSBuild15_9_Pack>false</UseMSBuild15_9_Pack>
+      <UseMSBuild15_9_Pack Condition=" '@(MSBuildMajorVersion)' > '15' OR ('@(MSBuildMajorVersion)' == '15' AND '@(MSBuildMinorVersion)' > '8') ">true</UseMSBuild15_9_Pack>
+      <UseMSBuild15_8_Pack>false</UseMSBuild15_8_Pack>
+      <UseMSBuild15_8_Pack Condition=" '$(NuGetToolVersion)' != '4.0.0' AND (! $(UseMSBuild15_9_Pack)) ">true</UseMSBuild15_8_Pack>
+      <UseNuGet4_Pack>false</UseNuGet4_Pack>
+      <UseNuGet4_Pack Condition=" (! $(UseMSBuild15_8_Pack)) AND (! $(UseMSBuild15_9_Pack)) ">true</UseNuGet4_Pack>
       <AdjustedNuspecOutputPath>$(BaseIntermediateOutputPath)$(Configuration)</AdjustedNuspecOutputPath>
       <AdjustedNuspecOutputPath Condition="@(_NuspecFilesNewLocation) == ''">$(BaseIntermediateOutputPath)</AdjustedNuspecOutputPath>
     </PropertyGroup>
@@ -208,9 +229,52 @@
       <Output TaskParameter="AbsolutePaths" PropertyName="NuspecFileAbsolutePath" />
     </ConvertToAbsolutePath>
 
-
     <!-- Call Pack -->
-    <PackTask Condition="$(UseNewPack)"
+    <PackTask Condition="$(UseMSBuild15_9_Pack)"
+              PackItem="$(PackProjectInputFile)"
+              PackageFiles="@(_PackageFiles)"
+              PackageFilesToExclude="@(_PackageFilesToExclude)"
+              PackageVersion="$(PackageVersion)"
+              PackageId="$(PackageId)"
+              Title="$(Title)"
+              Authors="$(Authors)"
+              Description="$(Description)"
+              Copyright="$(Copyright)"
+              RequireLicenseAcceptance="$(PackageRequireLicenseAcceptance)"
+              LicenseUrl="$(PackageLicenseUrl)"
+              ProjectUrl="$(PackageProjectUrl)"
+              IconUrl="$(PackageIconUrl)"
+              ReleaseNotes="$(PackageReleaseNotes)"
+              Tags="$(PackageTags)"
+              DevelopmentDependency="$(DevelopmentDependency)"
+              BuildOutputInPackage="@(_BuildOutputInPackage)"
+              TargetPathsToSymbols="@(_TargetPathsToSymbols)"
+              SymbolPackageFormat="symbols.nupkg"
+              TargetFrameworks="@(_TargetFrameworks)"
+              AssemblyName="$(AssemblyName)"
+              PackageOutputPath="$(PackageOutputAbsolutePath)"
+              IncludeSymbols="$(IncludeSymbols)"
+              IncludeSource="$(IncludeSource)"
+              PackageTypes="$(PackageType)"
+              IsTool="$(IsTool)"
+              RepositoryUrl="$(RepositoryUrl)"
+              RepositoryType="$(RepositoryType)"
+              SourceFiles="@(_SourceFiles->Distinct())"
+              NoPackageAnalysis="$(NoPackageAnalysis)"
+              MinClientVersion="$(MinClientVersion)"
+              Serviceable="$(Serviceable)"
+              FrameworkAssemblyReferences="@(_FrameworkAssemblyReferences)"
+              ContinuePackingAfterGeneratingNuspec="$(ContinuePackingAfterGeneratingNuspec)"
+              NuspecOutputPath="$(AdjustedNuspecOutputPath)"
+              IncludeBuildOutput="$(IncludeBuildOutput)"
+              BuildOutputFolder="$(BuildOutputTargetFolder)"
+              ContentTargetFolders="$(ContentTargetFolders)"
+              RestoreOutputPath="$(RestoreOutputAbsolutePath)"
+              NuspecFile="$(NuspecFileAbsolutePath)"
+              NuspecBasePath="$(NuspecBasePath)"
+              NuspecProperties="$(NuspecProperties)"/>
+
+    <PackTask Condition="$(UseMSBuild15_8_Pack)"
               PackItem="$(PackProjectInputFile)"
               PackageFiles="@(_PackageFiles)"
               PackageFilesToExclude="@(_PackageFilesToExclude)"
@@ -253,7 +317,7 @@
               NuspecBasePath="$(NuspecBasePath)"
               NuspecProperties="$(NuspecProperties)"/>
 
-    <PackTask Condition="! $(UseNewPack)"
+    <PackTask Condition="$(UseNuGet4_Pack)"
               PackItem="$(PackProjectInputFile)"
               PackageFiles="@(_PackageFiles)"
               PackageFilesToExclude="@(_PackageFilesToExclude)"

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -17,7 +17,6 @@ group Server
 group Client
     storage: none
     source https://api.nuget.org/v3/index.json
-    source /Users/dbrattli/Developer/packages
 
     nuget Fable.Core ~> 2
     nuget Fable.Elmish ~> 2

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -17,6 +17,7 @@ group Server
 group Client
     storage: none
     source https://api.nuget.org/v3/index.json
+    source /Users/dbrattli/Developer/packages
 
     nuget Fable.Core ~> 2
     nuget Fable.Elmish ~> 2
@@ -26,7 +27,7 @@ group Client
     nuget Fable.React ~> 4
     nuget Fulma ~> 1
     nuget Fulma.Extensions
-    nuget Fable.Elmish.Reaction ~> 2.1
+    nuget Fable.Elmish.Reaction ~> 2.2
 
     clitool dotnet-fable ~> 2
 

--- a/paket.lock
+++ b/paket.lock
@@ -4,7 +4,7 @@ GROUP Build
 STORAGE: NONE
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    BlackFox.VsWhere (0.3.2) - restriction: || (>= net462) (>= netstandard2.0)
+    BlackFox.VsWhere (1.0) - restriction: || (>= net462) (>= netstandard2.0)
       FSharp.Core (>= 4.0.0.1) - restriction: >= net45
       FSharp.Core (>= 4.2.3) - restriction: && (< net45) (>= netstandard2.0)
     Fake.Core.CommandLineParsing (5.10.1) - restriction: || (>= net46) (>= netstandard2.0)
@@ -97,8 +97,8 @@ NUGET
       System.Threading.Thread (>= 4.0) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
       System.Threading.ThreadPool (>= 4.0.10) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
       System.Threading.Timer (>= 4.0.1) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
-    Microsoft.Build (15.8.166) - restriction: || (>= net462) (>= netstandard2.0)
-      Microsoft.Build.Framework (>= 15.8.166) - restriction: || (>= net46) (>= netstandard2.0)
+    Microsoft.Build (15.9.20) - restriction: || (>= net462) (>= netstandard2.0)
+      Microsoft.Build.Framework (>= 15.9.20) - restriction: || (>= net46) (>= netstandard2.0)
       Microsoft.VisualStudio.Setup.Configuration.Interop (>= 1.16.30) - restriction: >= net46
       Microsoft.Win32.Registry (>= 4.3) - restriction: || (&& (< net46) (>= netstandard2.0)) (>= netcoreapp2.1)
       System.Collections.Immutable (>= 1.5) - restriction: || (>= net46) (>= netstandard2.0)
@@ -112,12 +112,12 @@ NUGET
       System.Text.Encoding.CodePages (>= 4.0.1) - restriction: || (&& (< net46) (>= netstandard2.0)) (>= netcoreapp2.1)
       System.Threading.Tasks.Dataflow (>= 4.5.24) - restriction: >= net46
       System.Threading.Tasks.Dataflow (>= 4.6) - restriction: || (&& (< net46) (>= netstandard2.0)) (>= netcoreapp2.1)
-    Microsoft.Build.Framework (15.8.166) - restriction: || (>= net462) (>= netstandard2.0)
+    Microsoft.Build.Framework (15.9.20) - restriction: || (>= net462) (>= netstandard2.0)
       System.Runtime.Serialization.Primitives (>= 4.1.1) - restriction: && (< net46) (>= netstandard2.0)
       System.Threading.Thread (>= 4.0) - restriction: && (< net46) (>= netstandard2.0)
-    Microsoft.Build.Tasks.Core (15.8.166) - restriction: || (>= net462) (>= netstandard2.0)
-      Microsoft.Build.Framework (>= 15.8.166) - restriction: || (>= net46) (>= netstandard2.0)
-      Microsoft.Build.Utilities.Core (>= 15.8.166) - restriction: || (>= net46) (>= netstandard2.0)
+    Microsoft.Build.Tasks.Core (15.9.20) - restriction: || (>= net462) (>= netstandard2.0)
+      Microsoft.Build.Framework (>= 15.9.20) - restriction: || (>= net46) (>= netstandard2.0)
+      Microsoft.Build.Utilities.Core (>= 15.9.20) - restriction: || (>= net46) (>= netstandard2.0)
       Microsoft.VisualStudio.Setup.Configuration.Interop (>= 1.16.30) - restriction: >= net46
       Microsoft.Win32.Registry (>= 4.3) - restriction: && (< net46) (>= netstandard2.0)
       System.CodeDom (>= 4.4) - restriction: && (< net46) (>= netstandard2.0)
@@ -129,8 +129,8 @@ NUGET
       System.Resources.Writer (>= 4.0) - restriction: && (< net46) (>= netstandard2.0)
       System.Threading.Tasks.Dataflow (>= 4.5.24) - restriction: >= net46
       System.Threading.Tasks.Dataflow (>= 4.6) - restriction: && (< net46) (>= netstandard2.0)
-    Microsoft.Build.Utilities.Core (15.8.166) - restriction: || (>= net462) (>= netstandard2.0)
-      Microsoft.Build.Framework (>= 15.8.166) - restriction: || (>= net46) (>= netstandard2.0)
+    Microsoft.Build.Utilities.Core (15.9.20) - restriction: || (>= net462) (>= netstandard2.0)
+      Microsoft.Build.Framework (>= 15.9.20) - restriction: || (>= net46) (>= netstandard2.0)
       Microsoft.VisualStudio.Setup.Configuration.Interop (>= 1.16.30) - restriction: >= net46
       Microsoft.Win32.Registry (>= 4.3) - restriction: && (< net46) (>= netstandard2.0)
       System.Collections.Immutable (>= 1.5) - restriction: || (>= net46) (>= netstandard2.0)
@@ -892,6 +892,12 @@ NUGET
       Fable.PowerPack (>= 2.0.1) - restriction: >= netstandard2.0
       Fable.React (>= 4.0.1) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.5.2) - restriction: >= netstandard2.0
+    Fable.Elmish.Reaction (2.2.1)
+      Fable.Core (>= 2.0.1) - restriction: >= netstandard2.0
+      Fable.Elmish (>= 2.0.3) - restriction: >= netstandard2.0
+      Fable.React (>= 2.1) - restriction: >= netstandard2.0
+      FSharp.Core (>= 4.5.3) - restriction: >= netstandard2.0
+      Reaction.AsyncRx (>= 2.0) - restriction: >= netstandard2.0
     Fable.Import.Browser (1.3) - restriction: >= netstandard2.0
       Fable.Core (>= 1.3.17) - restriction: >= netstandard1.6
     Fable.Import.HMR (0.1) - restriction: >= netstandard2.0
@@ -1196,13 +1202,6 @@ NUGET
     Thoth.Json (2.5) - restriction: >= netstandard2.0
       Fable.Core (>= 2.0) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.5.2) - restriction: >= netstandard2.0
-  remote: /Users/dbrattli/Developer/packages
-    Fable.Elmish.Reaction (2.2.1)
-      Fable.Core (>= 2.0.1) - restriction: >= netstandard2.0
-      Fable.Elmish (>= 2.0.3) - restriction: >= netstandard2.0
-      Fable.React (>= 2.1) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.5.3) - restriction: >= netstandard2.0
-      Reaction.AsyncRx (>= 2.0) - restriction: >= netstandard2.0
 
 GROUP Server
 STORAGE: NONE

--- a/paket.lock
+++ b/paket.lock
@@ -892,12 +892,6 @@ NUGET
       Fable.PowerPack (>= 2.0.1) - restriction: >= netstandard2.0
       Fable.React (>= 4.0.1) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.5.2) - restriction: >= netstandard2.0
-    Fable.Elmish.Reaction (2.1)
-      Fable.Core (>= 2.0.1) - restriction: >= netstandard2.0
-      Fable.Elmish (>= 2.0.3) - restriction: >= netstandard2.0
-      Fable.React (>= 2.1) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.5.3) - restriction: >= netstandard2.0
-      Reaction.AsyncRx (>= 2.0) - restriction: >= netstandard2.0
     Fable.Import.Browser (1.3) - restriction: >= netstandard2.0
       Fable.Core (>= 1.3.17) - restriction: >= netstandard1.6
     Fable.Import.HMR (0.1) - restriction: >= netstandard2.0
@@ -1202,6 +1196,13 @@ NUGET
     Thoth.Json (2.5) - restriction: >= netstandard2.0
       Fable.Core (>= 2.0) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.5.2) - restriction: >= netstandard2.0
+  remote: /Users/dbrattli/Developer/packages
+    Fable.Elmish.Reaction (2.2.1)
+      Fable.Core (>= 2.0.1) - restriction: >= netstandard2.0
+      Fable.Elmish (>= 2.0.3) - restriction: >= netstandard2.0
+      Fable.React (>= 2.1) - restriction: >= netstandard2.0
+      FSharp.Core (>= 4.5.3) - restriction: >= netstandard2.0
+      Reaction.AsyncRx (>= 2.0) - restriction: >= netstandard2.0
 
 GROUP Server
 STORAGE: NONE

--- a/src/Client/Client.fs
+++ b/src/Client/Client.fs
@@ -127,17 +127,13 @@ let asInfoMsg msg =
   | _ ->
       None
 
-let loadLetterString () =
-  AsyncRx.ofPromise (fetchAs<string> "/api/init" Decode.string [])
-  |> AsyncRx.map (Ok >> InitialLetterStringLoaded)
-  |> AsyncRx.catch (Result.Error >> InitialLetterStringLoaded >> AsyncRx.single)
-  |> AsyncRx.asStream "loading"
-
-
 let stream model msgs =
   match model with
   | Loading ->
-      loadLetterString ()
+    AsyncRx.ofPromise (fetchAs<string> "/api/init" Decode.string [])
+    |> AsyncRx.map (Ok >> InitialLetterStringLoaded)
+    |> AsyncRx.catch (Result.Error >> InitialLetterStringLoaded >> AsyncRx.single)
+    |> AsyncRx.asStream "loading"
 
   | Error exn ->
       msgs

--- a/src/Client/Info.fs
+++ b/src/Client/Info.fs
@@ -91,7 +91,7 @@ let view model dispatch =
         [ Column.column [] [ viewStatus dispatch model ] ]
     ]
 
-let stream (model : Model) (msgs : IAsyncObservable<Msg>) =
+let stream model msgs =
   if model.Remote then
     let websocket =
       AsyncRx.never()

--- a/src/Client/Magic.fs
+++ b/src/Client/Magic.fs
@@ -290,7 +290,7 @@ let extractedLetterString letterString =
       letterString
 
 
-let stream (model : Model) msgs =
+let stream model msgs =
   match model.Letters with
   | Local _ ->
       let letterString =


### PR DESCRIPTION
Streams in, streams out. Now everything is a stream. I've added some more functions `Stream.choose` and `Stream.chooseNamed` to dig into stream you want to send to a component. You still use `Stream.map` to get back out. Looks cleaner, so I hope we are not over-engineering things.

We now need to give the name of the message stream to `withMsgStream` so it knows the default name. Since the name is of type `'name` we cannot give a default ourselves. I think this is OK since it removes many `msgs |> AsyncRx.asStream "msgs"` within the code and it's good not to lock the type to a string.